### PR TITLE
handle empty inputs

### DIFF
--- a/fastzlib.go
+++ b/fastzlib.go
@@ -43,7 +43,10 @@ func (b UnsafeByte) Free() {
 
 // Compress returns the input compressed using zlib, or an error if encountered.
 func Compress(input []byte) ([]byte, error) {
-	cInput := (*C.char)(unsafe.Pointer(&input[0]))
+	var cInput *C.char
+	if len(input) != 0 {
+		cInput = (*C.char)(unsafe.Pointer(&input[0]))
+	}
 	ret := C.c_compress2(cInput, C.uint(len(input)))
 
 	// if there was an error compressing, return it and free the original message
@@ -62,8 +65,11 @@ func Compress(input []byte) ([]byte, error) {
 
 // Decompress returns the input decompressed using zlib, or an error if encountered.
 func Decompress(input []byte) ([]byte, error) {
+	var cInput *C.char
+	if len(input) != 0 {
+		cInput = (*C.char)(unsafe.Pointer(&input[0]))
+	}
 	// send the input byte without copying iy
-	cInput := (*C.char)(unsafe.Pointer(&input[0]))
 	ret := C.c_decompress(cInput, C.uint(len(input)))
 
 	// if there was an error decompressing, return it and free the original message

--- a/fastzlib_test.go
+++ b/fastzlib_test.go
@@ -68,6 +68,18 @@ func TestAllZlib(t *testing.T) {
 	}
 }
 
+func TestEmpty(t *testing.T) {
+	var empty []byte
+	_, err := Compress(empty)
+	if err != nil {
+		t.Fatalf("unexpected error compressing empty slice")
+	}
+	_, err = Decompress(empty)
+	if err == nil {
+		t.Fatalf("unexpected success decompressing empty slice")
+	}
+}
+
 func TestUnsafeZlib(t *testing.T) {
 	for _, i := range []int{10, 128, 1000, 1024 * 10, 1024 * 100, 1024 * 1024, 1024 * 1024 * 7} {
 		data, err := genData(i)


### PR DESCRIPTION
indexing 0 in a zero length byte slice causes a panic to happen. Use a nil pointer instead if the length of the slice is 0.
