### PR TITLE
Refer to zlib through pkg-config only

### DIFF
--- a/fastzlib.go
+++ b/fastzlib.go
@@ -8,7 +8,7 @@ import (
 )
 
 /*
-#cgo LDFLAGS: -lz
+#cgo pkg-config: zlib
 #include "fastzlib.h"
 #include <stdlib.h>
 */


### PR DESCRIPTION
DataDog/czlib already refers to zlib via pkg-config in all but one place
where manual `-lz` is used:

    .../src/github.com/DataDog/czlib$ git grep '#cgo'
    adler32.go:// #cgo pkg-config: zlib
    fastzlib.go:#cgo LDFLAGS: -lz			<-- NOTE
    zstream.go:#cgo CFLAGS: -Werror=implicit
    zstream.go:#cgo pkg-config: zlib

Which on e.g. SlapOS can lead to resulting build being linked to system
libz.so instead of libz provided via pkg-config and $PKG_CONFIG_PATH.

-> Fix it via referring to zlib only via pkg-config.

/cc @jmoiron, @DanielMorsing